### PR TITLE
Read from file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -12,19 +12,19 @@ int main(int argc, char *argv[])
     std::vector<std::vector<double>> faces;
     
     /* RUN THE ALGO ON THE BUNNY */
-    // Eigen::Matrix<double, -1, 3> V; // vertices of the provided data
-    // Eigen::Matrix<int, -1, 3> F; // triangle definitions of the provided data
-    // Eigen::Matrix<double, -1, 3> N; // per-vertex normals of the provided data
-    // igl::readOFF("../data/bunny.off", V, F);
-    // igl::per_vertex_normals(V, F, N);
-    // matrix_to_2dvector<double, 3>(V, vertices);
-    // matrix_to_2dvector<double, 3>(N, normals);
+    Eigen::Matrix<double, -1, 3> V; // vertices of the provided data
+    Eigen::Matrix<int, -1, 3> F; // triangle definitions of the provided data
+    Eigen::Matrix<double, -1, 3> N; // per-vertex normals of the provided data
+    igl::readOFF("../data/bunny.off", V, F);
+    igl::per_vertex_normals(V, F, N);
+    matrix_to_2dvector<double, 3>(V, vertices);
+    matrix_to_2dvector<double, 3>(N, normals);
 
     /* RUN THE ALGO ON A TXT FILE PRODUCED FROM utilities/data-utils.py */
     // utils::load_pts_from_file(vertices, normals, "../data/output.txt");
 
     /* RUN THE ALGO ON TXT FILES CONTAINING VERTICES AND NORMALS */
-    utils::load_vertices_and_normals_from_txt(vertices, normals, 78056, "../data/vertices_happy0-n=78056.txt", "../data/normals_happy0-n=78056.txt");
+    // utils::load_vertices_and_normals_from_txt(vertices, normals, 78056, "../data/vertices_happy0-n=78056.txt", "../data/normals_happy0-n=78056.txt");
 
     std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>> > R;
     // R = reconstruction<double>(vertices, normals, 75, 75, 75, 200.0, 4.0, 0.01, false);

--- a/main.cpp
+++ b/main.cpp
@@ -12,16 +12,19 @@ int main(int argc, char *argv[])
     std::vector<std::vector<double>> faces;
     
     /* RUN THE ALGO ON THE BUNNY */
-    Eigen::Matrix<double, -1, 3> V; // vertices of the provided data
-    Eigen::Matrix<int, -1, 3> F; // triangle definitions of the provided data
-    Eigen::Matrix<double, -1, 3> N; // per-vertex normals of the provided data
-    igl::readOFF("../data/bunny.off", V, F);
-    igl::per_vertex_normals(V, F, N);
-    matrix_to_2dvector<double, 3>(V, vertices);
-    matrix_to_2dvector<double, 3>(N, normals);
+    // Eigen::Matrix<double, -1, 3> V; // vertices of the provided data
+    // Eigen::Matrix<int, -1, 3> F; // triangle definitions of the provided data
+    // Eigen::Matrix<double, -1, 3> N; // per-vertex normals of the provided data
+    // igl::readOFF("../data/bunny.off", V, F);
+    // igl::per_vertex_normals(V, F, N);
+    // matrix_to_2dvector<double, 3>(V, vertices);
+    // matrix_to_2dvector<double, 3>(N, normals);
 
     /* RUN THE ALGO ON A TXT FILE PRODUCED FROM utilities/data-utils.py */
     // utils::load_pts_from_file(vertices, normals, "../data/output.txt");
+
+    /* RUN THE ALGO ON TXT FILES CONTAINING VERTICES AND NORMALS */
+    utils::load_vertices_and_normals_from_txt(vertices, normals, 78056, "../data/vertices_happy0-n=78056.txt", "../data/normals_happy0-n=78056.txt");
 
     std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>> > R;
     // R = reconstruction<double>(vertices, normals, 75, 75, 75, 200.0, 4.0, 0.01, false);

--- a/reconstruction.h
+++ b/reconstruction.h
@@ -43,6 +43,9 @@ namespace utils {
             cout << "Could not open file " << filename << endl;
         }
 }
+void load_vertices_and_normals_from_txt(std::vector<std::vector<double>> &v, std::vector<std::vector<double>> &n, std::string filename_vertices, std::string filename_normals){
+    
+}
 }
 
 namespace mtr {

--- a/reconstruction.h
+++ b/reconstruction.h
@@ -43,8 +43,19 @@ namespace utils {
             cout << "Could not open file " << filename << endl;
         }
 }
-void load_vertices_and_normals_from_txt(std::vector<std::vector<double>> &v, std::vector<std::vector<double>> &n, std::string filename_vertices, std::string filename_normals){
-    
+void load_vertices_and_normals_from_txt(std::vector<std::vector<double>> &vertices, std::vector<std::vector<double>> &normals, int n_lines, std::string filename_vertices, std::string filename_normals){
+    vertices.resize(n_lines);
+    normals.resize(n_lines);
+    std::ifstream infile_verts(filename_vertices), infile_norms(filename_normals);
+    for (int i=0; i<n_lines; i++){
+        std::vector<double> vert(3), norm(3);
+        for (int j=0; j<3; j++){
+            infile_verts >> vert[j];
+            infile_norms >> norm[j];
+        }
+        vertices[i] = vert;
+        normals[i] = norm;
+    }
 }
 }
 


### PR DESCRIPTION
Added another method to be able to read vertices and normals from txt file. This method is useful for working with Stanford's datasets which are of type .ply. ply files can be easily converted to txt using open3D library in Python and the same library helps us estimate normals and store them into a txt file.